### PR TITLE
Fix AttributeError: 'ParsedRequirement' object has no attribute 'req'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except ImportError:
 
 def load_requirements(fname):
     reqs = parse_requirements(fname, session="test")
-    return [str(ir.req) for ir in reqs]
+    return [str(ir.requirement) for ir in reqs]
 
 def get_property(prop, project):
     result = re.search(r'{}\s*=\s*[\'"]([^\'"]*)[\'"]'.format(prop), open(project + '/__init__.py').read())


### PR DESCRIPTION
I took the liberty to cast the fix proposed by nahimilega into a pull request.